### PR TITLE
Prototype: beautiful.init: Update init.lua #4

### DIFF
--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -194,9 +194,10 @@ function beautiful.init(config)
             -- Expand the '~' $HOME shortcut
             config = config:gsub("^~/", homedir .. "/")
             local dir = Gio.File.new_for_path(config):get_parent()
-            beautiful.theme_path = dir and (dir:get_path().."/") or nil
+            rawset(beautiful, "theme_path", dir and (dir:get_path().."/") or nil)
             theme = protected_call(dofile, config)
         elseif type(config) == 'table' then
+            rawset(beautiful, "theme_path", nil)
             theme = config
         end
 


### PR DESCRIPTION
Some behaviour that doesn't really seem right...

Doesn't fail on beautiful.init( my_config ) when my_config = a function
Doesn't fail on beautiful.init( my_config ) when my_config = a number

As far as I can tell if theme then only catches the case where the protected_call fails

Doesn't fail on beautiful.init( my_config ) when my_config = {}

Would also be nice if it returned true if there was no problem so as to do...
```
if not beautiful.init( path_this .. "themes/shelby/theme.lua" ) then
	beautiful.init( path_this .. "themes/shelby/.last.theme.lua" ) -- a proven config 
end
```
The above would be nice assuming a theme error would not cause a full reversion to the default rc.lua