### PR TITLE
Prototype: beautiful.init: Update init.lua #5

### DIFF
--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -190,7 +190,7 @@ function beautiful.init(config)
         local homedir = os.getenv("HOME")
 
         -- If `config` is the path to a theme file, run this file,
-        -- to make it into a table so it can be saved as the theme.
+        -- otherwise if it is a theme table, save it.
         t_config = type(config)
         if t_config == 'string' then
             -- Expand the '~' $HOME shortcut

--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -186,6 +186,7 @@ end
 --   containing all the theme values.
 function beautiful.init(config)
     if config then
+        local state, path = nil, nil
         local homedir = os.getenv("HOME")
 
         -- If `config` is the path to a theme file, run this file,
@@ -194,14 +195,16 @@ function beautiful.init(config)
             -- Expand the '~' $HOME shortcut
             config = config:gsub("^~/", homedir .. "/")
             local dir = Gio.File.new_for_path(config):get_parent()
-            rawset(beautiful, "theme_path", dir and (dir:get_path().."/") or nil)
+            path = dir and (dir:get_path().."/") or nil
             theme = protected_call(dofile, config)
+            if type(theme) == 'table' then state = next(theme) end
         elseif type(config) == 'table' then
-            rawset(beautiful, "theme_path", nil)
             theme = config
+            state = next(theme)
         end
+        rawset(beautiful, "theme_path", path)
 
-        if theme then
+        if state then
             -- expand '~'
             if homedir then
                 for k, v in pairs(theme) do
@@ -210,9 +213,11 @@ function beautiful.init(config)
             end
 
             if theme.font then set_font(theme.font) end
+            return true
         else
             theme = {}
-            return gears_debug.print_error("beautiful: error loading theme file " .. config)
+			local error = "TO DO"
+            return gears_debug.print_error("beautiful: error loading theme: " .. error)
         end
     else
         return gears_debug.print_error("beautiful: error loading theme: no theme specified")


### PR DESCRIPTION
Some behaviour that doesn't really seem right...

Doesn't fail on beautiful.init( my_config ) when my_config = a function
Doesn't fail on beautiful.init( my_config ) when my_config = a number

As far as I can tell `if theme then` only catches the case where the protected_call fails

Doesn't fail on beautiful.init( my_config ) when my_config = {}

Would also be nice if it returned true if there was no problem so as to do...
```
if not beautiful.init( path_this .. "themes/shelby/theme.lua" ) then
	beautiful.init( path_this .. "themes/shelby/.last.theme.lua" ) -- a proven config 
end
```
The above would be nice assuming a theme error would not cause a full reversion to the default rc.lua